### PR TITLE
Add `export` and `local` keywords before function declarations

### DIFF
--- a/gruggers-core/src/error.rs
+++ b/gruggers-core/src/error.rs
@@ -193,7 +193,7 @@ impl<A: Allocator> GrugError<A> {
 	pub fn new_error(error_kind: ErrorKind, function_name: &str, file_path: &OsStr, source_text: &str, err_span: SourceSpan, error_message: std::fmt::Arguments) -> Self where
 		A: Default,
 	{
-		// println!("{:?}", std::panic::Location::caller());
+		println!("{:?}", std::panic::Location::caller());
 		let alloc = A::default();
 		Self::new_error_in(error_kind, function_name, file_path, source_text, err_span, error_message, alloc)
 	}

--- a/gruggers-core/src/error.rs
+++ b/gruggers-core/src/error.rs
@@ -193,7 +193,7 @@ impl<A: Allocator> GrugError<A> {
 	pub fn new_error(error_kind: ErrorKind, function_name: &str, file_path: &OsStr, source_text: &str, err_span: SourceSpan, error_message: std::fmt::Arguments) -> Self where
 		A: Default,
 	{
-		println!("{:?}", std::panic::Location::caller());
+		// println!("{:?}", std::panic::Location::caller());
 		let alloc = A::default();
 		Self::new_error_in(error_kind, function_name, file_path, source_text, err_span, error_message, alloc)
 	}

--- a/gruggers/examples/fibonacci/main.rs
+++ b/gruggers/examples/fibonacci/main.rs
@@ -142,29 +142,29 @@ fn main () {
 			.set_mods_dir("gruggers/examples/fibonacci/mods")
 			.build_state().unwrap();
 
-		state.register_game_fn("print_string",       print_string      ).unwrap();
-		state.register_game_fn("print_number",       print_number      ).unwrap();
-		state.register_game_fn("list_number",        list_number       ).unwrap();
-		state.register_game_fn("print_list_number",  print_list_number ).unwrap();
-		state.register_game_fn("list_number_insert", list_number_insert).unwrap();
-		state.register_game_fn("list_number_remove", list_number_remove).unwrap();
-		state.register_game_fn("list_number_push",   list_number_push  ).unwrap();
-		state.register_game_fn("list_number_pop",    list_number_pop   ).unwrap();
-		state.register_game_fn("list_number_len",    list_number_len   ).unwrap();
-		state.register_game_fn("list_number_get",    list_number_get   ).unwrap();
-		state.register_game_fn("list_number_set",    list_number_set   ).unwrap();
+		state.register_host_fn("print_string",       print_string      ).unwrap();
+		state.register_host_fn("print_number",       print_number      ).unwrap();
+		state.register_host_fn("list_number",        list_number       ).unwrap();
+		state.register_host_fn("print_list_number",  print_list_number ).unwrap();
+		state.register_host_fn("list_number_insert", list_number_insert).unwrap();
+		state.register_host_fn("list_number_remove", list_number_remove).unwrap();
+		state.register_host_fn("list_number_push",   list_number_push  ).unwrap();
+		state.register_host_fn("list_number_pop",    list_number_pop   ).unwrap();
+		state.register_host_fn("list_number_len",    list_number_len   ).unwrap();
+		state.register_host_fn("list_number_get",    list_number_get   ).unwrap();
+		state.register_host_fn("list_number_set",    list_number_set   ).unwrap();
 		
-		state.all_game_fns_registered().unwrap();
+		state.all_host_fns_registered().unwrap();
 		STATE.write(state);
 		OBJECTS.write(HashMap::new());
 
 		let script_id = STATE.compile_grug_file("fib_script/entity-Fib.grug").unwrap();
 		let script = STATE.create_entity(script_id).unwrap();
 
-		let naive_id = STATE.get_on_fn_id("Fib", "on_fib_naive").unwrap();
-		let iterative_id = STATE.get_on_fn_id("Fib", "on_fib_iterative").unwrap();
-		let memo_id = STATE.get_on_fn_id("Fib", "on_fib_memoized").unwrap();
-		let memo_print_id = STATE.get_on_fn_id("Fib", "on_print_list").unwrap();
+		let naive_id = STATE.get_export_fn_id("Fib", "on_fib_naive").unwrap();
+		let iterative_id = STATE.get_export_fn_id("Fib", "on_fib_iterative").unwrap();
+		let memo_id = STATE.get_export_fn_id("Fib", "on_fib_memoized").unwrap();
+		let memo_print_id = STATE.get_export_fn_id("Fib", "on_print_list").unwrap();
 
 		println!("Naive implementation");
 		for i in 0..10 {

--- a/gruggers/examples/minimal/main.rs
+++ b/gruggers/examples/minimal/main.rs
@@ -22,13 +22,13 @@ fn main () {
 		.set_mods_dir("gruggers/examples/minimal/mods")
 		.set_mod_api_path("gruggers/examples/minimal/mod_api.json")
 		.build_state().unwrap();
-	unsafe{state.register_game_fn("print_string", print_string).unwrap()};
-	state.all_game_fns_registered().unwrap();
+	unsafe{state.register_host_fn("print_string", print_string).unwrap()};
+	state.all_host_fns_registered().unwrap();
 
 	let files = state.compile_all_files();
 	let id = *files[0].result.as_ref().unwrap();
 	let dog = state.create_entity(id).unwrap();
-	let on_bark_id = state.get_on_fn_id("Dog", "on_bark").unwrap();
+	let on_bark_id = state.get_export_fn_id("Dog", "on_bark").unwrap();
 
 	loop {
 		_ = state.update_files();

--- a/gruggers/examples/resources/main.rs
+++ b/gruggers/examples/resources/main.rs
@@ -31,14 +31,14 @@ fn main () {
 		.set_mods_dir("gruggers/examples/resources/mods")
 		.set_mod_api_path("gruggers/examples/resources/mod_api.json")
 		.build_state().unwrap();
-	unsafe{state.register_game_fn("print_string", print_string).unwrap()};
-	unsafe{state.register_game_fn("print_file", print_file).unwrap()};
-	state.all_game_fns_registered().unwrap();
+	unsafe{state.register_host_fn("print_string", print_string).unwrap()};
+	unsafe{state.register_host_fn("print_file", print_file).unwrap()};
+	state.all_host_fns_registered().unwrap();
 
 	let files = state.compile_all_files();
 	let id = *files[0].result.as_ref().unwrap();
 	let dog = state.create_entity(id).unwrap();
-	let on_bark_id = state.get_on_fn_id("Dog", "on_bark").unwrap();
+	let on_bark_id = state.get_export_fn_id("Dog", "on_bark").unwrap();
 
 	loop {
 		println!("{:?}", state.update_files());

--- a/gruggers/src/capi.rs
+++ b/gruggers/src/capi.rs
@@ -14,9 +14,9 @@ pub extern "C" fn grug_deinit(_: Option<Box<GrugState>>) {}
 /// # SAFETY
 /// same as [`GrugState::register_game_fn`]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn grug_register_game_fn(state: &mut GrugState, game_fn_name: NTStrPtr<'static>, func: GameFnPtrState<GrugState>) -> bool {
+pub unsafe extern "C" fn grug_register_host_fn(state: &mut GrugState, game_fn_name: NTStrPtr<'static>, func: GameFnPtrState<GrugState>) -> bool {
 	// SAFETY: This function is exposed to C and is inherently unsafe
-	unsafe{state.register_game_fn(game_fn_name.to_str(), func).is_ok()}
+	unsafe{state.register_host_fn(game_fn_name.to_str(), func).is_ok()}
 }
 
 #[unsafe(no_mangle)]
@@ -53,7 +53,7 @@ pub extern "C" fn grug_get_on_fn_ids(state: &GrugState) -> &[EventFnEntry<'_>] {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn grug_get_on_fn_id(state: &GrugState, entity_type: NTStrPtr<'_>, on_fn_name: NTStrPtr<'_>) -> GrugOnFnId {
-	state.get_on_fn_id(entity_type.to_str(), on_fn_name.to_str()).unwrap_or(INVALID_GRUG_ON_FN_ID)
+	state.get_export_fn_id(entity_type.to_str(), on_fn_name.to_str()).unwrap_or(INVALID_GRUG_ON_FN_ID)
 }
 
 /// # Safety
@@ -65,6 +65,6 @@ pub unsafe extern "C" fn grug_call_on_function(state: &GrugState, entity: &GrugE
 }
 
 #[unsafe(no_mangle)]
-pub fn grug_all_game_fns_registered(state: &GrugState) -> bool {
-	state.all_game_fns_registered().is_ok()
+pub fn grug_all_host_fns_registered(state: &GrugState) -> bool {
+	state.all_host_fns_registered().is_ok()
 }

--- a/gruggers/src/frontend/mod.rs
+++ b/gruggers/src/frontend/mod.rs
@@ -68,7 +68,7 @@ impl GrugState {
 					format_args!("Entity '{}' is not registered in the mod_api.json", entity_type),
 				)
 			)?;
-			let game_functions = self.mod_api.game_functions();
+			let game_functions = self.mod_api.host_fns();
 			
 			let resources = TypePropogator::new(
 				entity, 
@@ -84,14 +84,14 @@ impl GrugState {
 			// let mod_api_entity = self.mod_api.entities.get(entity_type);
 			let mut member_variables = Vec::new_in(&arena);
 			let mut on_functions = Vec::new_in(&arena);
-			on_functions.extend((0..entity.on_fns.len()).map(|_| None));
+			on_functions.extend((0..entity.export_fns.len()).map(|_| None));
 			let mut helper_functions = Vec::new_in(&arena);
 
 			ast.global_statements.into_iter().for_each(|statement| {
 				match statement {
 					GlobalStatement::Variable(st@MemberVariable      {..}) => member_variables.push(st),
 					GlobalStatement::OnFunction(st@OnFunction        {..}) => {
-						let (i, _) = entity.get_on_fn(st.name.to_str()).unwrap();
+						let (i, _) = entity.get_export_fn(st.name.to_str()).unwrap();
 						on_functions[i] = Some(&*Box2::leak(Box2::new_in(st, &arena)));
 					}
 					GlobalStatement::HelperFunction(st@HelperFunction{..}) => helper_functions.push(st),

--- a/gruggers/src/frontend/parser.rs
+++ b/gruggers/src/frontend/parser.rs
@@ -233,70 +233,144 @@ pub(crate) fn parse<'a>(tokens: &'a [Token], arena: &'a Arena, file_text: &'a st
 					assignment_expr,
 					span: name_token.span
 				}));
+			let global_variable = ast.parse_global_variable(&mut tokens, &arena)?;
+			ast.global_statements.push(GlobalStatement::Variable(global_variable));
+			consume_next_token_types(&mut tokens, &[TokenType::NewLine])?;
 
-				consume_next_token_types(&mut tokens, &[TokenType::NewLine])?;
+			newline_allowed = true;
+			newline_required = true;
+			just_seen_global = true;
+		// on_fn -> "export" + " " + name + "(" + arguments? + ")" + statements 
+		} else if let Ok(_) = consume_next_token_types(&mut tokens, &[TokenType::Export]) {
+			// Require space after Export Token
+			consume_space(&mut tokens)?;
 
-				newline_allowed = true;
-				newline_required = true;
-			} else if let Ok([name_token]) = assert_next_token_types(&tokens, &[TokenType::Word]) && name_token.value.starts_with("on_") {
-				let [name_token] = consume_next_token_types(&mut tokens, &[TokenType::Word]).unwrap();
-				let fn_name = name_token.value;
-				
-				// expect newline after each item
-				if newline_required {
-					return ast.new_parse_error(
-						name_token.span,
-						format_args!("Expected an empty line")
-					);
+			let [name_token] = consume_next_token_types(&mut tokens, &[TokenType::Word])?;
+
+			// Cannot have global function after helper function
+			if seen_helper_fn {
+				return Err(ParserError::OnFunctionAfterHelperFunctions{
+					name: name_token.value.to_string(),
+				});
+			}
+			// expect newline after each item
+			if newline_required {
+				return Err(ParserError::ExpectedNewLine{
+					line: name_token.span.line,
+				});
+			}
+
+			let fn_name = name_token.value;
+
+			consume_next_token_types(&mut tokens, &[TokenType::OpenParenthesis])?;
+
+			let parameters = if assert_next_token_types(&mut tokens, &[TokenType::Word]).is_ok() {
+				ast.parse_parameters(&mut tokens, arena)?
+			} else {
+				&[]
+			};
+			consume_next_token_types(&mut tokens, &[TokenType::CloseParenthesis])?;
+			
+			let body_statements = ast.parse_statements(&mut tokens, 0, 1, arena)?;
+
+			if body_statements.iter().all(|x| matches!(x, Statement::Comment{..} | Statement::EmptyLine)) {
+				return Err(ParserError::EmptyFunction{
+					name: fn_name.to_string(),
+				});
+			}
+
+			let on_fn = OnFunction{
+				name: Box::leak(NTStr::box_from_str_in(fn_name, arena)).as_ntstrptr(),
+				parameters,
+				body_statements,
+				span: name_token.span
+			};
+
+			let fn_name = on_fn.name.to_str();
+			if ast.on_fn_signatures.iter().find(|(name, _)| *name == fn_name).is_some() {
+				return Err(ParserError::AlreadyDefinedOnFn{
+					fn_name: Arc::from(fn_name),
+				});
+			}
+			
+			ast.on_fn_signatures.push((on_fn.name.to_str(), on_fn.parameters));
+			ast.global_statements.push(GlobalStatement::OnFunction(on_fn));
+
+			seen_on_fn = true;
+
+			newline_allowed = true;
+			newline_seen = false;
+			newline_required = true;
+
+			just_seen_global = false;
+			consume_next_token_types(&mut tokens, &[TokenType::NewLine])?;
+		// helper_fn -> "local" + " " + name + "(" + arguments? + ")" + type + statements 
+		} else if let Ok(_) = consume_next_token_types(&mut tokens, &[TokenType::Local]) {
+			consume_space(&mut tokens)?;
+			let [name_token] = consume_next_token_types(&mut tokens, &[TokenType::Word])?;
+			// expect newline after each item
+			if newline_required {
+				return Err(ParserError::ExpectedNewLine{
+					line: name_token.span.line,
+				});
+			}
+
+			let fn_name = name_token.value;
+
+			if ast.called_helper_fns.iter().find(|val| **val == fn_name).is_none() {
+				return Err(ParserError::HelperFnDefinedBeforeCall {
+					fn_name: fn_name.into(),
+				});
+			}
+
+			// This should never fail because this is checked before calling parse_helper_fn
+			consume_next_token_types(&mut tokens, &[TokenType::OpenParenthesis]).unwrap();
+
+			let parameters = if assert_next_token_types(&mut tokens, &[TokenType::Word]).is_ok() {
+				ast.parse_parameters(&mut tokens, arena)?
+			} else {
+				&[]
+			};
+			consume_next_token_types(&mut tokens, &[TokenType::CloseParenthesis])?;
+
+			// return type
+			let return_type = if let Ok([_, type_token]) = consume_next_token_types(&mut tokens, &[TokenType::Space, TokenType::Word]) {
+				match ast.parse_type(type_token, arena)? {
+					GrugType::Resource{..} => return Err(ParserError::HelperFnReturnTypeCantBeResource{
+						fn_name: fn_name.to_string(),
+					}),
+					GrugType::Entity{..}   => return Err(ParserError::HelperFnReturnTypeCantBeEntity{
+						fn_name: fn_name.to_string(),
+					}),
+					x => x,
 				}
+			} else {
+				GrugType::Void
+			};
+			
+			let body_statements = ast.parse_statements(&mut tokens, 0, 1, arena)?;
 
-				ast.current_function = fn_name;
+			if body_statements.iter().all(|x| matches!(x, Statement::Comment{..} | Statement::EmptyLine)) {
+				return Err(ParserError::EmptyFunction{
+					name: fn_name.to_string(),
+				});
+			}
 
-				// Cannot have global function after helper function
-				if seen_helper_fn {
-					return ast.new_parse_error(
-						name_token.span,
-						format_args!("{}() must be defined before all helper_ functions", fn_name)
-					);
-				}
-				consume_next_token_types(&mut tokens, &[TokenType::OpenParenthesis])?;
+			let helper_fn = HelperFunction{
+				name: Box::leak(NTStr::box_from_str_in(fn_name, arena)).as_ntstrptr(),
+				parameters,
+				body_statements,
+				return_type,
+				span: name_token.span,
+			};
 
-				let parameters = if assert_next_token_types(&tokens, &[TokenType::Word]).is_ok() {
-					ast.parse_parameters(&mut tokens, arena)?
-				} else {
-					&[]
-				};
-				consume_next_token_types(&mut tokens, &[TokenType::CloseParenthesis])?;
-				
-				let body_statements = ast.parse_statements(&mut tokens, 0, 1, arena)?;
+			seen_helper_fn = true;
 
-				if body_statements.iter().all(|x| matches!(x, Statement::Comment{..} | Statement::EmptyLine)) {
-					return ast.new_parse_error(
-						name_token.span,
-						format_args!("{}() can't be empty", fn_name),
-					);
-				}
-
-				let on_fn = OnFunction{
-					name: Box::leak(NTStr::box_from_str_in(fn_name, arena)).as_ntstrptr(),
-					parameters,
-					body_statements,
-					span: name_token.span
-				};
-
-				if ast.on_fn_signatures.iter().any(|(name, _)| *name == fn_name) {
-					return ast.new_parse_error(
-						name_token.span,
-						format_args!("The function '{}' was defined several times in the same file", fn_name),
-					);
-				}
-				ast.current_function = "member scope";
-				
-				ast.on_fn_signatures.push((fn_name, on_fn.parameters));
-				ast.global_statements.push(GlobalStatement::OnFunction(on_fn));
-
-				seen_on_fn = true;
-
+			if ast.helper_fn_signatures.iter().find(|(name, _)| *name == fn_name).is_some() {
+				return Err(ParserError::AlreadyDefinedHelperFunction{
+					fn_name: Arc::from(helper_fn.name.to_str()),
+				});
+			}
 				newline_allowed = true;
 				newline_seen = false;
 				newline_required = true;

--- a/gruggers/src/frontend/parser.rs
+++ b/gruggers/src/frontend/parser.rs
@@ -233,152 +233,85 @@ pub(crate) fn parse<'a>(tokens: &'a [Token], arena: &'a Arena, file_text: &'a st
 					assignment_expr,
 					span: name_token.span
 				}));
-			let global_variable = ast.parse_global_variable(&mut tokens, &arena)?;
-			ast.global_statements.push(GlobalStatement::Variable(global_variable));
-			consume_next_token_types(&mut tokens, &[TokenType::NewLine])?;
 
-			newline_allowed = true;
-			newline_required = true;
-			just_seen_global = true;
-		// on_fn -> "export" + " " + name + "(" + arguments? + ")" + statements 
-		} else if let Ok(_) = consume_next_token_types(&mut tokens, &[TokenType::Export]) {
-			// Require space after Export Token
-			consume_space(&mut tokens)?;
+				consume_next_token_types(&mut tokens, &[TokenType::NewLine])?;
 
-			let [name_token] = consume_next_token_types(&mut tokens, &[TokenType::Word])?;
-
-			// Cannot have global function after helper function
-			if seen_helper_fn {
-				return Err(ParserError::OnFunctionAfterHelperFunctions{
-					name: name_token.value.to_string(),
-				});
-			}
-			// expect newline after each item
-			if newline_required {
-				return Err(ParserError::ExpectedNewLine{
-					line: name_token.span.line,
-				});
-			}
-
-			let fn_name = name_token.value;
-
-			consume_next_token_types(&mut tokens, &[TokenType::OpenParenthesis])?;
-
-			let parameters = if assert_next_token_types(&mut tokens, &[TokenType::Word]).is_ok() {
-				ast.parse_parameters(&mut tokens, arena)?
-			} else {
-				&[]
-			};
-			consume_next_token_types(&mut tokens, &[TokenType::CloseParenthesis])?;
-			
-			let body_statements = ast.parse_statements(&mut tokens, 0, 1, arena)?;
-
-			if body_statements.iter().all(|x| matches!(x, Statement::Comment{..} | Statement::EmptyLine)) {
-				return Err(ParserError::EmptyFunction{
-					name: fn_name.to_string(),
-				});
-			}
-
-			let on_fn = OnFunction{
-				name: Box::leak(NTStr::box_from_str_in(fn_name, arena)).as_ntstrptr(),
-				parameters,
-				body_statements,
-				span: name_token.span
-			};
-
-			let fn_name = on_fn.name.to_str();
-			if ast.on_fn_signatures.iter().find(|(name, _)| *name == fn_name).is_some() {
-				return Err(ParserError::AlreadyDefinedOnFn{
-					fn_name: Arc::from(fn_name),
-				});
-			}
-			
-			ast.on_fn_signatures.push((on_fn.name.to_str(), on_fn.parameters));
-			ast.global_statements.push(GlobalStatement::OnFunction(on_fn));
-
-			seen_on_fn = true;
-
-			newline_allowed = true;
-			newline_seen = false;
-			newline_required = true;
-
-			just_seen_global = false;
-			consume_next_token_types(&mut tokens, &[TokenType::NewLine])?;
-		// helper_fn -> "local" + " " + name + "(" + arguments? + ")" + type + statements 
-		} else if let Ok(_) = consume_next_token_types(&mut tokens, &[TokenType::Local]) {
-			consume_space(&mut tokens)?;
-			let [name_token] = consume_next_token_types(&mut tokens, &[TokenType::Word])?;
-			// expect newline after each item
-			if newline_required {
-				return Err(ParserError::ExpectedNewLine{
-					line: name_token.span.line,
-				});
-			}
-
-			let fn_name = name_token.value;
-
-			if ast.called_helper_fns.iter().find(|val| **val == fn_name).is_none() {
-				return Err(ParserError::HelperFnDefinedBeforeCall {
-					fn_name: fn_name.into(),
-				});
-			}
-
-			// This should never fail because this is checked before calling parse_helper_fn
-			consume_next_token_types(&mut tokens, &[TokenType::OpenParenthesis]).unwrap();
-
-			let parameters = if assert_next_token_types(&mut tokens, &[TokenType::Word]).is_ok() {
-				ast.parse_parameters(&mut tokens, arena)?
-			} else {
-				&[]
-			};
-			consume_next_token_types(&mut tokens, &[TokenType::CloseParenthesis])?;
-
-			// return type
-			let return_type = if let Ok([_, type_token]) = consume_next_token_types(&mut tokens, &[TokenType::Space, TokenType::Word]) {
-				match ast.parse_type(type_token, arena)? {
-					GrugType::Resource{..} => return Err(ParserError::HelperFnReturnTypeCantBeResource{
-						fn_name: fn_name.to_string(),
-					}),
-					GrugType::Entity{..}   => return Err(ParserError::HelperFnReturnTypeCantBeEntity{
-						fn_name: fn_name.to_string(),
-					}),
-					x => x,
+				newline_allowed = true;
+				newline_required = true;
+			// local fn -> "local" + " " + name + "(" + arguments? + ")" + type + statements 
+			} else if let Ok([_]) = consume_next_token_types(&mut tokens, &[TokenType::Export]) {
+				let [name_token] = consume_next_token_types(&mut tokens, &[TokenType::Word])?;
+				let fn_name = name_token.value;
+				
+				// expect newline after each item
+				if newline_required {
+					return ast.new_parse_error(
+						name_token.span,
+						format_args!("Expected an empty line")
+					);
 				}
-			} else {
-				GrugType::Void
-			};
-			
-			let body_statements = ast.parse_statements(&mut tokens, 0, 1, arena)?;
 
-			if body_statements.iter().all(|x| matches!(x, Statement::Comment{..} | Statement::EmptyLine)) {
-				return Err(ParserError::EmptyFunction{
-					name: fn_name.to_string(),
-				});
-			}
+				ast.current_function = fn_name;
 
-			let helper_fn = HelperFunction{
-				name: Box::leak(NTStr::box_from_str_in(fn_name, arena)).as_ntstrptr(),
-				parameters,
-				body_statements,
-				return_type,
-				span: name_token.span,
-			};
+				// Cannot have global function after helper function
+				if seen_helper_fn {
+					return ast.new_parse_error(
+						name_token.span,
+						format_args!("{}() must be defined before all helper_ functions", fn_name)
+					);
+				}
+				consume_next_token_types(&mut tokens, &[TokenType::OpenParenthesis])?;
 
-			seen_helper_fn = true;
+				let parameters = if assert_next_token_types(&tokens, &[TokenType::Word]).is_ok() {
+					ast.parse_parameters(&mut tokens, arena)?
+				} else {
+					&[]
+				};
+				consume_next_token_types(&mut tokens, &[TokenType::CloseParenthesis])?;
+				
+				let body_statements = ast.parse_statements(&mut tokens, 0, 1, arena)?;
 
-			if ast.helper_fn_signatures.iter().find(|(name, _)| *name == fn_name).is_some() {
-				return Err(ParserError::AlreadyDefinedHelperFunction{
-					fn_name: Arc::from(helper_fn.name.to_str()),
-				});
-			}
+				if body_statements.iter().all(|x| matches!(x, Statement::Comment{..} | Statement::EmptyLine)) {
+					return ast.new_parse_error(
+						name_token.span,
+						format_args!("{}() can't be empty", fn_name),
+					);
+				}
+
+				let on_fn = OnFunction{
+					name: Box::leak(NTStr::box_from_str_in(fn_name, arena)).as_ntstrptr(),
+					parameters,
+					body_statements,
+					span: name_token.span
+				};
+
+				if ast.on_fn_signatures.iter().any(|(name, _)| *name == fn_name) {
+					return ast.new_parse_error(
+						name_token.span,
+						format_args!("The function '{}' was defined several times in the same file", fn_name),
+					);
+				}
+				ast.current_function = "member scope";
+				
+				ast.on_fn_signatures.push((fn_name, on_fn.parameters));
+				ast.global_statements.push(GlobalStatement::OnFunction(on_fn));
+
+				seen_on_fn = true;
+
 				newline_allowed = true;
 				newline_seen = false;
 				newline_required = true;
 
 				consume_next_token_types(&mut tokens, &[TokenType::NewLine])?;
-			// helper_fn -> "local" + " " + name + "(" + arguments? + ")" + type + statements 
-			} else if let Ok([name_token]) = assert_next_token_types(&tokens, &[TokenType::Word]) && name_token.value.starts_with("helper_") {
-				let [name_token] = consume_next_token_types(&mut tokens, &[TokenType::Word]).unwrap();
+			// export fn -> "local" + " " + name + "(" + arguments? + ")" + type + statements 
+			} else if let Ok([name_token]) = consume_next_token_types(&mut tokens, &[TokenType::Word]) && name_token.value.starts_with("helper_") {
+				let [name_token] = consume_next_token_types(&mut tokens, &[TokenType::Word])?;
+				if !name_token.value.starts_with("_") {
+					return ast.new_parse_error(
+						name_token.span,
+						format_args!("Local function name must begin with `_`")
+					);
+				}
 				let fn_name = name_token.value;
 				// expect newline after each item
 				if newline_required {

--- a/gruggers/src/frontend/parser.rs
+++ b/gruggers/src/frontend/parser.rs
@@ -152,9 +152,9 @@ pub(crate) struct Ast<'arena> {
 	// needed to report error location
 	pub(crate) current_function: &'arena str,
 	pub(crate) global_statements: Vec<GlobalStatement<'arena>, &'arena Arena>,
-	pub(crate) called_helper_fns: Vec<&'arena str, &'arena Arena>, 
-	pub(crate) helper_fn_signatures: Vec<(&'arena str, (GrugType<'arena>, &'arena [Parameter<'arena>])), &'arena Arena>,
-	pub(crate) on_fn_signatures: Vec<(&'arena str, &'arena [Parameter<'arena>]), &'arena Arena>,
+	pub(crate) called_local_functions: Vec<&'arena str, &'arena Arena>, 
+	pub(crate) local_fn_signatures: Vec<(&'arena str, (GrugType<'arena>, &'arena [Parameter<'arena>])), &'arena Arena>,
+	pub(crate) export_fn_signatures: Vec<(&'arena str, &'arena [Parameter<'arena>]), &'arena Arena>,
 }
 
 pub(crate) fn parse<'a>(tokens: &'a [Token], arena: &'a Arena, file_text: &'a str, file_path: &'a OsStr) -> Result<Ast<'a>, GrugError<Arena>> {
@@ -238,8 +238,8 @@ pub(crate) fn parse<'a>(tokens: &'a [Token], arena: &'a Arena, file_text: &'a st
 
 				newline_allowed = true;
 				newline_required = true;
-			// local fn -> "local" + " " + name + "(" + arguments? + ")" + type + statements 
-			} else if let Ok([_]) = consume_next_token_types(&mut tokens, &[TokenType::Export]) {
+			// export fn -> "export" + " " + name + "(" + arguments? + ")" + statements 
+			} else if let Ok([_, _]) = consume_next_token_types(&mut tokens, &[TokenType::Export, TokenType::Space]) {
 				let [name_token] = consume_next_token_types(&mut tokens, &[TokenType::Word])?;
 				let fn_name = name_token.value;
 				
@@ -257,7 +257,7 @@ pub(crate) fn parse<'a>(tokens: &'a [Token], arena: &'a Arena, file_text: &'a st
 				if seen_helper_fn {
 					return ast.new_parse_error(
 						name_token.span,
-						format_args!("{}() must be defined before all helper_ functions", fn_name)
+						format_args!("{}() must be defined before all local functions", fn_name)
 					);
 				}
 				consume_next_token_types(&mut tokens, &[TokenType::OpenParenthesis])?;
@@ -285,7 +285,7 @@ pub(crate) fn parse<'a>(tokens: &'a [Token], arena: &'a Arena, file_text: &'a st
 					span: name_token.span
 				};
 
-				if ast.on_fn_signatures.iter().any(|(name, _)| *name == fn_name) {
+				if ast.export_fn_signatures.iter().any(|(name, _)| *name == fn_name) {
 					return ast.new_parse_error(
 						name_token.span,
 						format_args!("The function '{}' was defined several times in the same file", fn_name),
@@ -293,7 +293,7 @@ pub(crate) fn parse<'a>(tokens: &'a [Token], arena: &'a Arena, file_text: &'a st
 				}
 				ast.current_function = "member scope";
 				
-				ast.on_fn_signatures.push((fn_name, on_fn.parameters));
+				ast.export_fn_signatures.push((fn_name, on_fn.parameters));
 				ast.global_statements.push(GlobalStatement::OnFunction(on_fn));
 
 				seen_on_fn = true;
@@ -303,8 +303,8 @@ pub(crate) fn parse<'a>(tokens: &'a [Token], arena: &'a Arena, file_text: &'a st
 				newline_required = true;
 
 				consume_next_token_types(&mut tokens, &[TokenType::NewLine])?;
-			// export fn -> "local" + " " + name + "(" + arguments? + ")" + type + statements 
-			} else if let Ok([name_token]) = consume_next_token_types(&mut tokens, &[TokenType::Word]) && name_token.value.starts_with("helper_") {
+			// local fn -> "local" + " " + name + "(" + arguments? + ")" + type + statements 
+			} else if let Ok([_, _]) = consume_next_token_types(&mut tokens, &[TokenType::Local, TokenType::Space]) {
 				let [name_token] = consume_next_token_types(&mut tokens, &[TokenType::Word])?;
 				if !name_token.value.starts_with("_") {
 					return ast.new_parse_error(
@@ -323,7 +323,7 @@ pub(crate) fn parse<'a>(tokens: &'a [Token], arena: &'a Arena, file_text: &'a st
 
 				ast.current_function = fn_name;
 
-				if !ast.called_helper_fns.contains(&fn_name) {
+				if !ast.called_local_functions.contains(&fn_name) {
 					return ast.new_parse_error(
 						name_token.span,
 						format_args!("{}() is defined before the first time it gets called", fn_name)
@@ -379,7 +379,7 @@ pub(crate) fn parse<'a>(tokens: &'a [Token], arena: &'a Arena, file_text: &'a st
 
 				seen_helper_fn = true;
 
-				if ast.helper_fn_signatures.iter().any(|(name, _)| *name == fn_name) {
+				if ast.local_fn_signatures.iter().any(|(name, _)| *name == fn_name) {
 					return ast.new_parse_error(
 						name_token.span,
 						format_args!("The function '{}' was defined several times in the same file", fn_name),
@@ -387,7 +387,7 @@ pub(crate) fn parse<'a>(tokens: &'a [Token], arena: &'a Arena, file_text: &'a st
 				}
 				ast.current_function = "member scope";
 
-				ast.helper_fn_signatures.push((fn_name, (helper_fn.return_type, helper_fn.parameters)));
+				ast.local_fn_signatures.push((fn_name, (helper_fn.return_type, helper_fn.parameters)));
 				ast.global_statements.push(GlobalStatement::HelperFunction(helper_fn));
 
 				newline_allowed = true;
@@ -448,9 +448,9 @@ impl<'a> Ast<'a> {
 			last_token_span,
 			current_function: "member scope",
 			global_statements: Vec::new_in(arena),
-			called_helper_fns: Vec::new_in(arena),
-			helper_fn_signatures: Vec::new_in(arena),
-			on_fn_signatures: Vec::new_in(arena),
+			called_local_functions: Vec::new_in(arena),
+			local_fn_signatures: Vec::new_in(arena),
+			export_fn_signatures: Vec::new_in(arena),
 		}
 	}
 
@@ -820,10 +820,10 @@ impl<'a> Ast<'a> {
 					let value: &'a NTStr  = Box::leak(NTStr::box_from_str_in(value, arena));
 					// a word token can actually be a function call
 					if let Ok([_]) = consume_next_token_types(tokens, &[TokenType::OpenParenthesis]) {
-						if value.as_str().starts_with("helper_")
-							&& !self.called_helper_fns.contains(&value.as_str())
+						if value.as_str().starts_with("_")
+							&& !self.called_local_functions.contains(&value.as_str())
 						{
-							self.called_helper_fns.push(value);
+							self.called_local_functions.push(value);
 						}
 						
 						// immediate ")" | (expr + ("," + " " + expr)*) + ")"

--- a/gruggers/src/frontend/tokenizer.rs
+++ b/gruggers/src/frontend/tokenizer.rs
@@ -90,6 +90,8 @@ impl std::fmt::Display for TokenType {
 			Self::Break => write!(f, "'break'"),
 			Self::Return => write!(f, "'return'"),
 			Self::Continue => write!(f, "'continue'"),
+			Self::Export => write!(f, "'export'"),
+			Self::Local => write!(f, "'local'"),
 			Self::Space => write!(f, "space (' ')"),
 			Self::Indentation => write!(f, "indentation"),
 			Self::String => write!(f, "string"),

--- a/gruggers/src/frontend/tokenizer.rs
+++ b/gruggers/src/frontend/tokenizer.rs
@@ -44,6 +44,8 @@ pub enum TokenType {
 	Break,
 	Return,
 	Continue,
+	Export,
+	Local,
 	Space,
 	Indentation,
 	String,
@@ -174,6 +176,8 @@ pub fn tokenize<'a, 'b, P: AsRef<OsStr>>(file_text: &'b str, arena: &'a Arena, f
 		token_match_word!(b"break" => TokenType::Break);
 		token_match_word!(b"return" => TokenType::Return);
 		token_match_word!(b"continue" => TokenType::Continue);
+		token_match_word!(b"export" => TokenType::Export);
+		token_match_word!(b"local" => TokenType::Local);
 
 		// Spaces
 		let lit_len = b" ".len();

--- a/gruggers/src/frontend/type_propagation.rs
+++ b/gruggers/src/frontend/type_propagation.rs
@@ -16,7 +16,7 @@ use crate::frontend::GlobalStatement;
 use crate::nt;
 use crate::arena::Arena;
 use crate::frontend::parser::Ast;
-use crate::mod_api::{ModApiEntity, ModApiGameFn};
+use crate::mod_api::{ModApiEntity, ModApiHostFn};
 
 use allocator_api2::vec::Vec;
 use allocator_api2::boxed::Box;
@@ -25,7 +25,7 @@ pub(super) struct TypePropogator<'mod_api, 'arena> {
 	file_text: &'arena str,
 	file_path: &'arena OsStr,
 	entity: &'mod_api ModApiEntity<'mod_api>,
-	game_fns: &'mod_api HashMap<&'mod_api NTStr, ModApiGameFn<'mod_api>>,
+	game_fns: &'mod_api HashMap<&'mod_api NTStr, ModApiHostFn<'mod_api>>,
 	game_fn_ptrs: &'arena HashMap<&'static str, GameFnPtr>,
 	resources: HashSet<OsString>,
 	current_mod_name: &'arena OsStr,
@@ -39,7 +39,7 @@ pub(super) struct TypePropogator<'mod_api, 'arena> {
 impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 	pub fn new (
 		entity: &'mod_api ModApiEntity, 
-		game_fns: &'mod_api HashMap<&'mod_api NTStr, ModApiGameFn>, 
+		game_fns: &'mod_api HashMap<&'mod_api NTStr, ModApiHostFn>, 
 		game_fn_ptrs: &'arena HashMap<&'static str, GameFnPtr>, 
 		mod_name: &'arena OsStr, 
 		mods_dir_path: &'mod_api OsStr, 
@@ -85,7 +85,7 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 			.iter_mut().filter_map(|st| match st {GlobalStatement::Variable(x) => Some(x), _ => None});
 		for variable in variables {
 			self.check_global_expr(&variable.assignment_expr, variable.name.to_str())?;
-			let result_ty = self.fill_expr(&ast.helper_fn_signatures, &mut variable.assignment_expr, arena)?;
+			let result_ty = self.fill_expr(&ast.local_fn_signatures, &ast.export_fn_signatures, &mut variable.assignment_expr, arena)?;
 
 			if let ExprData::Identifier(name) = &variable.assignment_expr.data 
 				&& name.to_str() == "me" {
@@ -109,7 +109,7 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 			.iter_mut().filter_map(|st| match st {GlobalStatement::OnFunction(x) => Some(x), _ => None})
 			.collect::<Vec<_>>();
 		for (on_fn_name, mod_api_on_fn) in 
-			self.entity.on_fns.iter()
+			self.entity.export_fns.iter()
 		{
 			let Some((current_index, current_on_fn)) = 
 				on_functions.iter_mut().enumerate()
@@ -127,7 +127,7 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 				self.current_fn_name = Some(on_fn_name);
 				return self.new_type_propagator_error(
 					current_on_fn.span,
-					format_args!("The function '{}' needs to be moved before or after a different on_ function, according to the entity '{}' in mod_api.json", current_on_fn.name.to_str(), entity_name)
+					format_args!("The function '{}' needs to be moved before or after a different export function, according to the entity '{}' in mod_api.json", current_on_fn.name.to_str(), entity_name)
 				);
 			}
 			previous_on_fn_index = current_index;
@@ -165,13 +165,13 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 			for param in current_on_fn.parameters {
 				self.add_local_variable(param.name.to_str(), param.ty, param.name_span)?;
 			}
-			self.fill_statements(&ast.helper_fn_signatures, current_on_fn.body_statements, &GrugType::Void, arena)?;
+			self.fill_statements(&ast.local_fn_signatures, &ast.export_fn_signatures, current_on_fn.body_statements, &GrugType::Void, arena)?;
 			self.pop_scope();
 
 			debug_assert!(self.current_fn_name == Some(current_on_fn.name.to_str()));
 			self.current_fn_name = None;
 		}
-		let entity_on_functions = &self.entity.on_fns;
+		let entity_on_functions = &self.entity.export_fns;
 		for on_fn in on_functions {
 			let on_fn_name = on_fn.name.to_ntstr();
 			if !entity_on_functions.iter().any(|(name, _)| *name == on_fn_name) {
@@ -205,7 +205,7 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 					for param in *parameters {
 						self.add_local_variable(param.name.to_str(), param.ty, param.name_span)?;
 					}
-					self.fill_statements(&ast.helper_fn_signatures, body_statements, return_type, arena)?;
+					self.fill_statements(&ast.local_fn_signatures, &ast.export_fn_signatures, body_statements, return_type, arena)?;
 
 					if *return_type != GrugType::Void && !matches!(body_statements.last(), Some(Statement::Return{..})) {
 						return self.new_type_propagator_error(
@@ -226,7 +226,7 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 	}
 	
 	// out parameter self.current_on_fn_calls_helper_fn
-	fn fill_statements(&mut self, helper_fns: &[(&str, (GrugType<'arena>, &[Parameter<'arena>]))], statements: &mut [Statement<'arena>], expected_return_type: &GrugType<'arena>, arena: &'arena Arena) -> Result<(), GrugError<Arena>> {
+	fn fill_statements(&mut self, helper_fns: &[(&str, (GrugType<'arena>, &[Parameter<'arena>]))], export_fns: &[(&str, &[Parameter<'arena>])], statements: &mut [Statement<'arena>], expected_return_type: &GrugType<'arena>, arena: &'arena Arena) -> Result<(), GrugError<Arena>> {
 		self.push_scope();
 		for statement in statements {
 			match statement {
@@ -236,7 +236,7 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 					assignment_expr,
 					name_span,
 				} => {
-					let result_ty = self.fill_expr(helper_fns, assignment_expr, arena)?;
+					let result_ty = self.fill_expr(helper_fns, export_fns, assignment_expr, arena)?;
 					
 					if let Some(ty) = ty {
 						self.add_local_variable(name.to_str(), **ty, *name_span)?;
@@ -273,7 +273,7 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 					}
 				}
 				Statement::Call(expr) => {
-					self.fill_expr(helper_fns, expr, arena)?;
+					self.fill_expr(helper_fns, export_fns, expr, arena)?;
 				}
 				Statement::If {
 					condition,
@@ -286,14 +286,14 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 					let mut if_block = if_block;
 					let mut else_block = else_block;
 					loop {
-						let cond_type = self.fill_expr(helper_fns, condition, arena)?;
+						let cond_type = self.fill_expr(helper_fns, export_fns, condition, arena)?;
 						if cond_type != GrugType::Bool {
 							return self.new_type_propagator_error(
 								condition.span,
 								format_args!("If condition must be bool but got '{}'", cond_type)
 							);
 						}
-						self.fill_statements(helper_fns, if_block, expected_return_type, arena)?;
+						self.fill_statements(helper_fns, export_fns, if_block, expected_return_type, arena)?;
 						if !else_block.is_empty() {
 							if *is_chained {
 								debug_assert!(else_block.len() == 1);
@@ -304,7 +304,7 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 								};
 								continue;
 							} else {
-								self.fill_statements(helper_fns, else_block, expected_return_type, arena)?;
+								self.fill_statements(helper_fns, export_fns, else_block, expected_return_type, arena)?;
 							}
 						}
 						break;
@@ -316,7 +316,7 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 					condition,
 					block,
 				} => {
-					let cond_type = self.fill_expr(helper_fns, condition, arena)?;
+					let cond_type = self.fill_expr(helper_fns, export_fns, condition, arena)?;
 					if cond_type != GrugType::Bool {
 						return self.new_type_propagator_error(
 							condition.span,
@@ -324,7 +324,7 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 						);
 					}
 					self.num_while_loops_deep += 1;
-					self.fill_statements(helper_fns, block, expected_return_type, arena)?;
+					self.fill_statements(helper_fns, export_fns, block, expected_return_type, arena)?;
 					self.num_while_loops_deep -= 1;
 
 				}
@@ -333,7 +333,7 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 					expr,
 				} => {
 					let (return_ty, span) = expr.as_mut()
-						.map(|expr| Ok((self.fill_expr(helper_fns, expr, arena)?, expr.span)))
+						.map(|expr| Ok((self.fill_expr(helper_fns, export_fns, expr, arena)?, expr.span)))
 						.unwrap_or(Ok((GrugType::Void, *return_span)))?;
 					if *expected_return_type != (GrugType::Id{custom_name: None}) && *expected_return_type != return_ty {
 						if return_ty == GrugType::Void {
@@ -408,10 +408,10 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 				name_span: _,
 			} => {
 				let fn_name = fn_name.to_str();
-				if fn_name.starts_with("helper_") {
+				if fn_name.starts_with("_") {
 					return self.new_type_propagator_error(
 						assignment_expr.span,
-						format_args!("The global variable '{}' isn't allowed to call helper functions", name)
+						format_args!("The global variable '{}' isn't allowed to call local functions", name)
 					);
 				}
 				args.iter().map(|argument| self.check_global_expr(argument, name))
@@ -423,7 +423,7 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 	}
 
 	// out parameter self.current_on_fn_calls_helper_fn
-	fn fill_expr(&mut self, helper_fns: &[(&str, (GrugType<'arena>, &[Parameter<'arena>]))], assignment_expr: &mut Expr<'arena>, arena: &'arena Arena) -> Result<GrugType<'arena>, GrugError<Arena>> {
+	fn fill_expr(&mut self, helper_fns: &[(&str, (GrugType<'arena>, &[Parameter<'arena>]))], export_fns: &[(&str, &[Parameter<'arena>])], assignment_expr: &mut Expr<'arena>, arena: &'arena Arena) -> Result<GrugType<'arena>, GrugError<Arena>> {
 		// MUST be None before type propogation
 		assert!(assignment_expr.result_type.is_none());
 		let result_ty = match &mut assignment_expr.data {
@@ -455,7 +455,7 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 						format_args!("Found '{0}' directly next to another '{0}', which can be simplified by just removing both of them", op)
 					);
 				}
-				let result_ty = self.fill_expr(helper_fns, expr, arena)?;
+				let result_ty = self.fill_expr(helper_fns, export_fns, expr, arena)?;
 				match (op, &result_ty) {
 					(UnaryOperator::Not, GrugType::Bool) => (),
 					(UnaryOperator::Not, got) => return self.new_type_propagator_error(
@@ -477,8 +477,8 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 				op,
 				op_span,
 			} => {
-				let result_0 = self.fill_expr(helper_fns, left, arena)?;
-				let result_1 = self.fill_expr(helper_fns, right, arena)?;
+				let result_0 = self.fill_expr(helper_fns, export_fns, left, arena)?;
+				let result_1 = self.fill_expr(helper_fns, export_fns, right, arena)?;
 				match (&result_1, *op) {
 					(GrugType::String, BinaryOperator::DoubleEquals) | 
 					(GrugType::String, BinaryOperator::NotEquals) => (),
@@ -569,10 +569,10 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 			} => {
 				let fn_name = fn_name.to_str();
 				if let Some((_, (return_ty, sig_arguments))) = helper_fns.iter().find(|(name, _)| *name == fn_name) {
-					self.check_arguments(helper_fns, fn_name, *name_span, sig_arguments, args, arena)?;
+					self.check_arguments(helper_fns, export_fns, fn_name, *name_span, sig_arguments, args, arena)?;
 					*return_ty
 				} else if let Some(game_fn) = self.game_fns.get(fn_name) {
-					self.check_arguments(helper_fns, fn_name, *name_span, game_fn.parameters, args, arena)?;
+					self.check_arguments(helper_fns, export_fns, fn_name, *name_span, game_fn.parameters, args, arena)?;
 					if let Some(game_fn_ptr) = self.game_fn_ptrs.get(fn_name) {
 						*ptr = Some(*game_fn_ptr);
 						game_fn.return_ty
@@ -583,15 +583,15 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 						// 	format_args!("Game function {} was not registered", fn_name)
 						// );
 					}
-				} else if fn_name.starts_with("on_") {
+				} else if fn_name.starts_with("_") {
 					return self.new_type_propagator_error(
 						*name_span,
-						format_args!("Mods aren't allowed to call their own on_ functions")
+						format_args!("The local function '{}' was not defined by this grug file", fn_name)
 					);
-				} else if fn_name.starts_with("helper_") {
+				} else if export_fns.iter().any(|(name, _)| *name == fn_name) {
 					return self.new_type_propagator_error(
 						*name_span,
-						format_args!("The helper function '{}' was not defined by this grug file", fn_name)
+						format_args!("Mods aren't allowed to call their own export functions")
 					);
 				} else {
 					return self.new_type_propagator_error(
@@ -601,7 +601,7 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 				}
 			},
 			ExprData::Parenthesized(expr) => {
-				self.fill_expr(helper_fns, expr, arena)?
+				self.fill_expr(helper_fns, export_fns, expr, arena)?
 			},
 		};
 		assignment_expr.result_type = Some(Box::leak(Box::new_in(result_ty, arena)));
@@ -610,6 +610,7 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 
 	fn check_arguments(&mut self, 
 		helper_fns: &[(&str, (GrugType<'arena>, &[Parameter<'arena>]))], 
+		export_fns: &[(&str, &[Parameter<'arena>])], 
 		function_name: &str, 
 		name_span: SourceSpan, 
 		signature: &[Parameter<'_>], 
@@ -624,14 +625,14 @@ impl<'mod_api: 'arena, 'arena> TypePropogator<'mod_api, 'arena> {
 			);
 		} else if signature.len() < arguments.len() {
 			let arg = &mut arguments[signature.len()];
-			let got_type = self.fill_expr(helper_fns, arg, arena)?;
+			let got_type = self.fill_expr(helper_fns, export_fns, arg, arena)?;
 			return self.new_type_propagator_error(
 				arg.span,
 				format_args!("Function call '{}' got an unexpected extra argument with type {}", function_name, got_type)
 			);
 		}
 		for (param, arg) in signature.iter().zip(arguments) {
-			let arg_result_ty = self.fill_expr(helper_fns, arg, arena)?;
+			let arg_result_ty = self.fill_expr(helper_fns, export_fns, arg, arena)?;
 			// TODO: Make this better
 			// If argument is resource
 			if let GrugType::Resource{extension} = param.ty 

--- a/gruggers/src/lib.rs
+++ b/gruggers/src/lib.rs
@@ -11,7 +11,7 @@ pub mod state;
 
 pub mod capi;
 mod xar;
-mod arena;
+pub mod arena;
 
 mod cachemap;
 mod watcher;

--- a/gruggers/src/mod_api.rs
+++ b/gruggers/src/mod_api.rs
@@ -16,7 +16,7 @@ use json::JsonValue;
 // reference to them must have a 'self lifetime
 pub(crate) struct ModApi {
 	entities: HashMap<&'static NTStr, ModApiEntity<'static>>,
-	game_functions: HashMap<&'static NTStr, ModApiGameFn<'static>>,
+	host_fns: HashMap<&'static NTStr, ModApiHostFn<'static>>,
 	_arena: Arena,
 }
 
@@ -24,8 +24,8 @@ impl ModApi {
 	pub fn entities<'a>(&'a self) -> &'a HashMap<&'a NTStr, ModApiEntity<'a>> {
 		&self.entities
 	}
-	pub fn game_functions<'a>(&'a self) -> &'a HashMap<&'a NTStr, ModApiGameFn<'a>> {
-		&self.game_functions
+	pub fn host_fns<'a>(&'a self) -> &'a HashMap<&'a NTStr, ModApiHostFn<'a>> {
+		&self.host_fns
 	}
 }
 
@@ -33,24 +33,24 @@ impl ModApi {
 pub(crate) struct ModApiEntity<'a> {
 	#[allow(dead_code)]
 	pub(crate) description: Option<&'a str>,
-	pub(crate) on_fns: &'a [(&'a NTStr, ModApiOnFn<'a>)],
+	pub(crate) export_fns: &'a [(&'a NTStr, ModApiExportFn<'a>)],
 }
 
 impl<'a> ModApiEntity<'a> {
-	pub(crate) fn get_on_fn(&self, name: &str) -> Option<(usize, &ModApiOnFn<'_>)> {
-		self.on_fns.iter().enumerate().find_map(|(i, (fn_name, func))| (name == fn_name.as_str()).then_some((i, func)))
+	pub(crate) fn get_export_fn(&self, name: &str) -> Option<(usize, &ModApiExportFn<'_>)> {
+		self.export_fns.iter().enumerate().find_map(|(i, (fn_name, func))| (name == fn_name.as_str()).then_some((i, func)))
 	}
 }
 
 #[derive(Debug)]
-pub(crate) struct ModApiOnFn<'a> {
+pub(crate) struct ModApiExportFn<'a> {
 	#[allow(dead_code)]
 	pub(super) description: Option<&'a str>,
 	pub(super) parameters: &'a [Parameter<'a>],
 }
 
 #[derive(Debug)]
-pub(crate) struct ModApiGameFn<'a> {
+pub(crate) struct ModApiHostFn<'a> {
 	#[allow(dead_code)]
 	pub(crate) description: Option<&'a str>,
 	pub(crate) return_ty: GrugType<'a>,
@@ -130,26 +130,26 @@ pub(crate) fn get_mod_api_from_text(mod_api_path: impl AsRef<Path>, mod_api_text
 			}
 		};
 
-		// optional "on_fns" object
-		let on_fns = match &entity_values.get("on_functions") {
+		// optional "export_functions" object
+		let export_fns = match &entity_values.get("export_functions") {
 			None => &vec![],
-			Some(on_fns) => {
-				let JsonValue::Array(on_fns) = on_fns else {
-					return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.on_functions is not an array"));
+			Some(export_fns) => {
+				let JsonValue::Array(export_fns) = export_fns else {
+					return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.export_functions is not an array"));
 				};
-				on_fns
+				export_fns
 			}
 		};
-		let on_fns = on_fns.iter().enumerate().map(|(i, function)| {
+		let export_fns = export_fns.iter().enumerate().map(|(i, function)| {
 			let JsonValue::Object(function) = function else {
-				return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.on_functions[{i}] is not an object"));
+				return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.export_functions[{i}] is not an object"));
 			};
 			// "name" string
 			let fn_name = match function.get("name") {
-				None => return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.on_functions[{i}].name missing")),
+				None => return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.export_functions[{i}].name missing")),
 				Some(str) => {
 					let Some(str) = str.as_str() else {
-						return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.on_functions[{i}].name is not a string"));
+						return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.export_functions[{i}].name is not a string"));
 					};
 					&*Box::leak(NTStr::box_from_str_in(str, &arena))
 				}
@@ -159,7 +159,7 @@ pub(crate) fn get_mod_api_from_text(mod_api_path: impl AsRef<Path>, mod_api_text
 				None => None,
 				Some(str) => {
 					let Some(str) = str.as_str() else {
-						return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.on_functions[\"{fn_name}\"].description is not a string"));
+						return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.export_functions[\"{fn_name}\"].description is not a string"));
 					};
 					Some(Box::leak(NTStr::box_from_str_in(str, &arena)).as_str())
 				}
@@ -170,44 +170,44 @@ pub(crate) fn get_mod_api_from_text(mod_api_path: impl AsRef<Path>, mod_api_text
 				None => &vec![],
 				Some(parameters) => {
 					let JsonValue::Array(parameters) = parameters else {
-						return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.on_functions[\"{fn_name}\"].arguments is not an array"));
+						return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.export_functions[\"{fn_name}\"].arguments is not an array"));
 					};
 					parameters
 				}
 			};
 			let parameters = parameters.iter().enumerate().map(|(j, param_values)| {
 				let JsonValue::Object(param_values) = param_values else {
-					return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.on_functions[\"{fn_name}\"].arguments[{j}] is not an object"))
+					return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.export_functions[\"{fn_name}\"].arguments[{j}] is not an object"))
 				};
 				// "name" string
 				let param_name = match param_values.get("name") {
-					None => return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.on_functions[{i}].arguments[{j}].name missing")),
+					None => return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.export_functions[{i}].arguments[{j}].name missing")),
 					Some(str) => {
 						let Some(str) = str.as_str() else {
-							return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.on_functions[{i}].arguments[{j}].name is not a string"));
+							return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.export_functions[{i}].arguments[{j}].name is not a string"));
 						};
 						&*Box::leak(NTStr::box_from_str_in(str, &arena))
 					}
 				};
 				// "type" string
 				let ty = match param_values.get("type") {
-					None => return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.on_functions[{i}].arguments[{j}].type missing")),
+					None => return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.export_functions[{i}].arguments[{j}].type missing")),
 					Some(str) => {
 						let Some(str) = str.as_str() else {
-							return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.on_functions[{i}].arguments[{j}].type is not a string"));
+							return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.export_functions[{i}].arguments[{j}].type is not a string"));
 						};
 						Box::leak(NTStr::box_from_str_in(str, &arena)).as_str()
 					}
 				};
 				let ty = match ty {
 					// arguments can't be void
-					"void"     => return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.on_functions[\"{fn_name}\"].arguments[\"{param_name}\"].type is void")),
+					"void"     => return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.export_functions[\"{fn_name}\"].arguments[\"{param_name}\"].type is void")),
 					"bool"     => GrugType::Bool,
 					"number"   => GrugType::Number,
 					"string"   => GrugType::String,
 					"id"       => GrugType::Id{custom_name: None},
-					"resource"     => return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.on_functions[\"{fn_name}\"].arguments[\"{param_name}\"].type is resource")),
-					"entity"     => return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.on_functions[\"{fn_name}\"].arguments[\"{param_name}\"].type is entity")),
+					"resource"     => return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.export_functions[\"{fn_name}\"].arguments[\"{param_name}\"].type is resource")),
+					"entity"     => return Err(mod_api_err!(entity_name => "root.entities.{entity_name}.export_functions[\"{fn_name}\"].arguments[\"{param_name}\"].type is entity")),
 					type_name => {
 						let extra_value = Box::leak(NTStr::box_from_str_in(type_name, &arena));
 						GrugType::Id {
@@ -230,14 +230,14 @@ pub(crate) fn get_mod_api_from_text(mod_api_path: impl AsRef<Path>, mod_api_text
 				temp.extend(parameters);
 				temp.leak()
 			};
-			Ok((fn_name, ModApiOnFn{
+			Ok((fn_name, ModApiExportFn{
 				description,
 				parameters,
 			}))
 		}).collect::<Result<Vec<_>, _>>()?;
-		let on_fns = {
+		let export_fns = {
 			let mut temp = Vec::new_in(&arena);
-			temp.extend(on_fns);
+			temp.extend(export_fns);
 			temp.leak()
 		};
 		let entity_name = unsafe{
@@ -247,25 +247,25 @@ pub(crate) fn get_mod_api_from_text(mod_api_path: impl AsRef<Path>, mod_api_text
 		};
 		Ok((entity_name, ModApiEntity{
 			description,
-			on_fns
+			export_fns
 		}))
 	}).collect::<Result<HashMap<_, _>, _>>()?;
 	
 	
-	// "game_functions" object
-	let game_functions = match mod_api_root.get("game_functions") {
-		None => return Err(mod_api_err!(root => "root.game_functions does not exist")),
-		Some(game_functions) => {
-			let JsonValue::Object(game_functions) = game_functions else {
-				return Err(mod_api_err!(root => "root.game_functions is not an object"));
+	// "host_functions" object
+	let host_fns = match mod_api_root.get("host_functions") {
+		None => return Err(mod_api_err!(root => "root.host_functions does not exist")),
+		Some(host_fns) => {
+			let JsonValue::Object(host_fns) = host_fns else {
+				return Err(mod_api_err!(root => "root.host_functions is not an object"));
 			};
-			game_functions
+			host_fns
 		}
 	};
 
-	let game_functions = game_functions.iter().map(|(fn_name, game_fn_values)| {
+	let host_fns = host_fns.iter().map(|(fn_name, game_fn_values)| {
 		let JsonValue::Object(game_fn_values) = game_fn_values else {
-			return Err(mod_api_err!(fn_name => "root.game_functions.{fn_name} is not an object"));
+			return Err(mod_api_err!(fn_name => "root.host_functions.{fn_name} is not an object"));
 		};
 		// optional "description" string
 		let description = match game_fn_values.get("description") {
@@ -291,31 +291,31 @@ pub(crate) fn get_mod_api_from_text(mod_api_path: impl AsRef<Path>, mod_api_text
 
 		let parameters = parameters.iter().enumerate().map(|(i, param_values)| {
 			let JsonValue::Object(param_values) = param_values else {
-				return Err(mod_api_err!(fn_name => "root.game_functions.{fn_name}.arguments[{i}] is not an object"));
+				return Err(mod_api_err!(fn_name => "root.host_functions.{fn_name}.arguments[{i}] is not an object"));
 			};
 			// "name" string
 			let param_name = match param_values.get("name") {
-				None => return Err(mod_api_err!(fn_name => "root.game_functions.{fn_name}.arguments[{i}].name is missing")),
+				None => return Err(mod_api_err!(fn_name => "root.host_functions.{fn_name}.arguments[{i}].name is missing")),
 				Some(str) => {
 					let Some(str) = str.as_str() else {
-						return Err(mod_api_err!(fn_name => "root.game_functions.{fn_name}.arguments.name is not a string"));
+						return Err(mod_api_err!(fn_name => "root.host_functions.{fn_name}.arguments.name is not a string"));
 					};
 					&*Box::leak(NTStr::box_from_str_in(str, &arena))
 				}
 			};
 			// "type" string
 			let ty = match param_values.get("type") {
-				None => return Err(mod_api_err!(fn_name => "root.game_functions.{fn_name}.arguments[\"{param_name}\"].type is missing")),
+				None => return Err(mod_api_err!(fn_name => "root.host_functions.{fn_name}.arguments[\"{param_name}\"].type is missing")),
 				Some(str) => {
 					let Some(str) = str.as_str() else {
-						return Err(mod_api_err!(fn_name => "root.game_functions.{fn_name}.arguments[\"{param_name}\"].type is not a string"));
+						return Err(mod_api_err!(fn_name => "root.host_functions.{fn_name}.arguments[\"{param_name}\"].type is not a string"));
 					};
 					Box::leak(NTStr::box_from_str_in(str, &arena)).as_str()
 				}
 			};
 			let ty = match ty {
 				// arguments can't be void
-				"void"     => return Err(mod_api_err!(fn_name => "root.game_functions.{fn_name}.arguments[\"{param_name}\"].type is void")),
+				"void"     => return Err(mod_api_err!(fn_name => "root.host_functions.{fn_name}.arguments[\"{param_name}\"].type is void")),
 				"bool"     => GrugType::Bool,
 				"number"      => GrugType::Number,
 				"string"   => GrugType::String,
@@ -323,10 +323,10 @@ pub(crate) fn get_mod_api_from_text(mod_api_path: impl AsRef<Path>, mod_api_text
 				"entity"   => {
 					// "entity_type" string
 					let entity_type = match param_values.get("entity_type") {
-						None => return Err(mod_api_err!(fn_name => "root.game_functions.{fn_name}.arguments[\"{param_name}\"].entity_type is missing")),
+						None => return Err(mod_api_err!(fn_name => "root.host_functions.{fn_name}.arguments[\"{param_name}\"].entity_type is missing")),
 						Some(str) => {
 							let Some(str) = str.as_str() else {
-								return Err(mod_api_err!(fn_name => "root.game_functions.{fn_name}.arguments[\"{param_name}\"].entity_type is not a string"));
+								return Err(mod_api_err!(fn_name => "root.host_functions.{fn_name}.arguments[\"{param_name}\"].entity_type is not a string"));
 							};
 							&*Box::leak(NTStr::box_from_str_in(str, &arena))
 						}
@@ -341,10 +341,10 @@ pub(crate) fn get_mod_api_from_text(mod_api_path: impl AsRef<Path>, mod_api_text
 				"resource" => {
 					// "resource_extension" string
 					let extension = match param_values.get("resource_extension") {
-						None => return Err(mod_api_err!(fn_name => "root.game_functions.{fn_name}.arguments[\"{param_name}\"].resource_extension is missing")),
+						None => return Err(mod_api_err!(fn_name => "root.host_functions.{fn_name}.arguments[\"{param_name}\"].resource_extension is missing")),
 						Some(str) => {
 							let Some(str) = str.as_str() else {
-								return Err(mod_api_err!(fn_name => "root.game_functions.{fn_name}.arguments[\"{param_name}\"].resource_extension is not a string"));
+								return Err(mod_api_err!(fn_name => "root.host_functions.{fn_name}.arguments[\"{param_name}\"].resource_extension is not a string"));
 							};
 							&*Box::leak(NTStr::box_from_str_in(str, &arena))
 						}
@@ -379,7 +379,7 @@ pub(crate) fn get_mod_api_from_text(mod_api_path: impl AsRef<Path>, mod_api_text
 			None => "void",
 			Some(str) => {
 				let Some(str) = str.as_str() else {
-					return Err(mod_api_err!(fn_name => "root.game_functions.{fn_name}.return_type is not a string"));
+					return Err(mod_api_err!(fn_name => "root.host_functions.{fn_name}.return_type is not a string"));
 				};
 				&*Box::leak(NTStr::box_from_str_in(str, &arena))
 			}
@@ -390,8 +390,8 @@ pub(crate) fn get_mod_api_from_text(mod_api_path: impl AsRef<Path>, mod_api_text
 			"number"      => GrugType::Number,
 			"string"   => GrugType::String,
 			"id"       => GrugType::Id{custom_name: None},
-			"entity"     => return Err(mod_api_err!(fn_name => "root.game_functions.{fn_name}.return_type is entity")),
-			"resource"     => return Err(mod_api_err!(fn_name => "root.game_functions.{fn_name}.return_type is resource")),
+			"entity"     => return Err(mod_api_err!(fn_name => "root.host_functions.{fn_name}.return_type is entity")),
+			"resource"     => return Err(mod_api_err!(fn_name => "root.host_functions.{fn_name}.return_type is resource")),
 			type_name => {
 				let extra_value = Box::leak(NTStr::box_from_str_in(type_name, &arena)).as_ntstrptr();
 				GrugType::Id {
@@ -405,7 +405,7 @@ pub(crate) fn get_mod_api_from_text(mod_api_path: impl AsRef<Path>, mod_api_text
 				Box::leak(NTStr::box_from_str_in(fn_name, &arena))
 			)
 		};
-		Ok((fn_name, ModApiGameFn{
+		Ok((fn_name, ModApiHostFn{
 			return_ty,
 			description,
 			parameters
@@ -414,7 +414,7 @@ pub(crate) fn get_mod_api_from_text(mod_api_path: impl AsRef<Path>, mod_api_text
 
 	Ok(ModApi{
 		entities: unsafe{std::mem::transmute::<HashMap<&'_ NTStr, ModApiEntity<'_>>, HashMap<&'static NTStr, ModApiEntity<'static>>>(entities)},
-		game_functions: unsafe{std::mem::transmute::<HashMap<&'_ NTStr, ModApiGameFn<'_>>, HashMap<&'static NTStr, ModApiGameFn<'static>>>(game_functions)},
+		host_fns: unsafe{std::mem::transmute::<HashMap<&'_ NTStr, ModApiHostFn<'_>>, HashMap<&'static NTStr, ModApiHostFn<'static>>>(host_fns)},
 		_arena: arena,
 	})
 }

--- a/gruggers/src/serde.rs
+++ b/gruggers/src/serde.rs
@@ -391,6 +391,7 @@ mod de {
 					let Some(name) = get_object_field(global_statement, "name", "GLOBAL_ON_FN")?.as_str() else {
 						return Err(JsonDeserializeError::OnFunctionNameNotString)
 					};
+					output.push_str("export ");
 					output.push_str(name);
 					output.push_str("(");
 					if let Ok(parameters) = get_object_field(global_statement, "arguments", "GLOBAL_ON_FN") {
@@ -406,6 +407,7 @@ mod de {
 					let Some(name) = get_object_field(global_statement, "name", "GLOBAL_HELPER_FN")?.as_str() else {
 						return Err(JsonDeserializeError::HelperFunctionNameNotString)
 					};
+					output.push_str("local ");
 					output.push_str(name);
 					output.push_str("(");
 					if let Ok(parameters) = get_object_field(global_statement, "arguments", "GLOBAL_HELPER_FN") {

--- a/gruggers/src/state.rs
+++ b/gruggers/src/state.rs
@@ -291,7 +291,7 @@ impl GrugState {
 				event_fn_name : unsafe{init_globals.as_ntstrptr().detach_lifetime()},
 				index      : 0,
 			});
-			for (i, (event_fn_name, _)) in entity.on_fns.iter().enumerate() {
+			for (i, (event_fn_name, _)) in entity.export_fns.iter().enumerate() {
 				on_fns.push(EventFnEntry{
 					// SAFETY: All EventFnEntries we give out have a 'self
 					// lifetime, which is the same as the 'mod_api lifetime they
@@ -330,21 +330,30 @@ impl GrugState {
 		&self.mods_dir_path
 	}
 
-	pub fn get_on_fn_id(&self, entity_type: &str, on_fn_name: &str) -> Result<GrugOnFnId, StateError> {
+	pub fn get_export_fn_id(&self, entity_type: &str, on_fn_name: &str) -> Result<GrugOnFnId, GrugError<Arena>> {
 		if !self.mod_api.entities().contains_key(entity_type) {
-			return Err(StateError::UnknownEntityType{
-				entity_type: String::from(entity_type),
-			});
+			return Err(GrugError::new_error(
+				ErrorKind::INIT_ERROR,
+				"",
+				"".as_ref(),
+				"",
+				SourceSpan{offset: 0, line: 0},
+				format_args!("mod api does not define an entity named {}", entity_type),
+			));
 		}
 		for (i, on_fn_entry) in self.on_functions.iter().enumerate() {
 			if on_fn_entry.entity_type() == entity_type && on_fn_entry.event_fn_name() == on_fn_name {
 				return Ok(i as u64)
 			}
 		}
-		Err(StateError::UnknownOnFunction {
-			entity_type: String::from(entity_type),
-			on_function_name : String::from(on_fn_name ),
-		})
+		return Err(GrugError::new_error(
+			ErrorKind::INIT_ERROR,
+			"",
+			"".as_ref(),
+			"",
+			SourceSpan{offset: 0, line: 0},
+			format_args!("'{}' does not export a function named '{}'", entity_type, on_fn_name),
+		));
 	}
 	
 	pub fn get_on_fn_name(&self, on_fn_id: GrugOnFnId) -> Option<&str> {
@@ -355,11 +364,16 @@ impl GrugState {
 		&self.on_functions
 	}
 
-	pub fn get_entity_on_functions(&self, entity_type: &str) -> Result<&[EventFnEntry<'_>], StateError> {
+	pub fn get_entity_on_functions(&self, entity_type: &str) -> Result<&[EventFnEntry<'_>], GrugError<Arena>> {
 		if !self.mod_api.entities().contains_key(entity_type) {
-			return Err(StateError::UnknownEntityType{
-				entity_type: String::from(entity_type),
-			});
+			return Err(GrugError::new_error(
+				ErrorKind::INIT_ERROR,
+				"",
+				"".as_ref(),
+				"",
+				SourceSpan{offset: 0, line: 0},
+				format_args!("mod api does not define an entity named {}", entity_type),
+			));
 		}
 		let mut start = 0;
 		while start != self.on_functions.len() && self.on_functions[start].entity_type() != entity_type {
@@ -375,16 +389,26 @@ impl GrugState {
 	/// # Safety
 	/// The actual signature of the returned function should match the
 	/// signature in the mod_api
-	pub unsafe fn register_game_fn(&mut self, name: &'static str, ptr: GameFnPtrState<Self>) -> Result<(), StateError> {
-		if !self.mod_api.game_functions().contains_key(name) {
-			Err(StateError::UnknownGameFunction{
-				game_function_name: name,
-			})
+	pub unsafe fn register_host_fn(&mut self, name: &'static str, ptr: GameFnPtrState<Self>) -> Result<(), GrugError<Arena>> {
+		if !self.mod_api.host_fns().contains_key(name) {
+			return Err(GrugError::new_error(
+				ErrorKind::INIT_ERROR,
+				"",
+				"".as_ref(),
+				"",
+				SourceSpan{offset: 0, line: 0},
+				format_args!("Host function named '{}' is not found in mod_api.json", name),
+			));
 		} else {
 			match self.game_functions.entry(name) {
-				Entry::Occupied(_) => Err(StateError::ReregisteringGameFunction{
-					game_function_name: name,
-				}),
+				Entry::Occupied(_) => return Err(GrugError::new_error(
+					ErrorKind::INIT_ERROR,
+					"",
+					"".as_ref(),
+					"",
+					SourceSpan{offset: 0, line: 0},
+					format_args!("Host function named '{}' has already been registered", name),
+				)),
 				Entry::Vacant(x) => {
 					x.insert(GameFnPtr::from_ptr(ptr));
 					Ok(())
@@ -406,7 +430,7 @@ impl GrugState {
 			GrugValue{void: ()}
 		}
 
-		for name in self.mod_api.game_functions().keys() {
+		for name in self.mod_api.host_fns().keys() {
 			self.game_functions.entry(Box::leak(Box::from(name.as_str()))).or_insert(GameFnPtr::from_ptr(dummy_host_fn));
 		}
 	}
@@ -421,8 +445,8 @@ impl GrugState {
 		Some(string)
 	}
 
-	pub fn all_game_fns_registered(&self) -> Result<(), GrugError<Arena>> {
-		for game_fn_name in self.mod_api.game_functions().keys() {
+	pub fn all_host_fns_registered(&self) -> Result<(), GrugError<Arena>> {
+		for game_fn_name in self.mod_api.host_fns().keys() {
 			if !self.game_functions.contains_key(game_fn_name.as_str()) {
 				return Err(GrugError::new_error(
 					ErrorKind::INIT_ERROR,
@@ -533,43 +557,6 @@ impl GrugState {
 		self.current_on_fn_id.set(old_on_fn_id);
 
 		ret_val
-	}
-}
-
-#[derive(Debug)]
-pub enum StateError {
-	UnknownEntityType{
-		entity_type: String
-	},
-	UnknownOnFunction {
-		entity_type: String,
-		on_function_name: String,
-	},
-	UnknownGameFunction {
-		game_function_name: &'static str,
-	},
-	ReregisteringGameFunction {
-		game_function_name: &'static str,
-	}
-}
-
-impl std::fmt::Display for StateError {
-	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		match self {
-			Self::UnknownEntityType{
-				entity_type,
-			} => write!(f, "mod api does not define an entity named {}", entity_type),
-			Self::UnknownOnFunction {
-				entity_type,
-				on_function_name,
-			} => write!(f, "'{}' does not contain an on_function named '{}'", entity_type, on_function_name),
-			Self::UnknownGameFunction {
-				game_function_name,
-			} => write!(f, "Game function named '{}' is not found in mod_api.json", game_function_name),
-			Self::ReregisteringGameFunction {
-				game_function_name,
-			} => write!(f, "Game function named '{}' has already been registered", game_function_name),
-		}
 	}
 }
 

--- a/gruggers/tests/grug_bench/main.rs
+++ b/gruggers/tests/grug_bench/main.rs
@@ -41,7 +41,7 @@ mod test_bindings {
 			.build_state()
 			.unwrap();
 		register_game_functions(&mut state);
-		state.all_game_fns_registered().unwrap();
+		state.all_host_fns_registered().unwrap();
 		Box::new(state)
 	}
 
@@ -52,7 +52,7 @@ mod test_bindings {
 	}
 
 	extern "C" fn get_on_fn_id(state: &GrugState, entity_name: NTStrPtr<'_>, on_fn_name: NTStrPtr<'_>) -> GrugOnFnId {
-		state.get_on_fn_id(entity_name.to_str(), on_fn_name.to_str())
+		state.get_export_fn_id(entity_name.to_str(), on_fn_name.to_str())
 			.unwrap()
 	}
 
@@ -122,15 +122,15 @@ mod game_functions {
 	}
 
 	pub fn register_game_functions(state: &mut GrugState) { unsafe {
-		state.register_game_fn("print_number", game_fn_print_number).unwrap();
-		state.register_game_fn("print_bool"  , game_fn_print_bool  ).unwrap();
-		state.register_game_fn("get_1"       , game_fn_get_1       ).unwrap();
-		state.register_game_fn("get_mass"    , game_fn_get_mass    ).unwrap();
-		state.register_game_fn("get_number"  , game_fn_get_number  ).unwrap();
-		state.register_game_fn("x"           , game_fn_x           ).unwrap();
-		state.register_game_fn("y"           , game_fn_y           ).unwrap();
-		state.register_game_fn("sqrt"        , game_fn_sqrt        ).unwrap();
-		state.register_game_fn("set_acc"     , game_fn_set_acc     ).unwrap();
+		state.register_host_fn("print_number", game_fn_print_number).unwrap();
+		state.register_host_fn("print_bool"  , game_fn_print_bool  ).unwrap();
+		state.register_host_fn("get_1"       , game_fn_get_1       ).unwrap();
+		state.register_host_fn("get_mass"    , game_fn_get_mass    ).unwrap();
+		state.register_host_fn("get_number"  , game_fn_get_number  ).unwrap();
+		state.register_host_fn("x"           , game_fn_x           ).unwrap();
+		state.register_host_fn("y"           , game_fn_y           ).unwrap();
+		state.register_host_fn("sqrt"        , game_fn_sqrt        ).unwrap();
+		state.register_host_fn("set_acc"     , game_fn_set_acc     ).unwrap();
 	}}
 }
 

--- a/gruggers/tests/grug_bench/main.rs
+++ b/gruggers/tests/grug_bench/main.rs
@@ -119,6 +119,7 @@ mod game_functions {
 		safe fn game_fn_y           <'a>(state: &'a GrugState, arguments: *const GrugValue) -> GrugValue;
 		safe fn game_fn_sqrt        <'a>(state: &'a GrugState, arguments: *const GrugValue) -> GrugValue;
 		safe fn game_fn_set_acc     <'a>(state: &'a GrugState, arguments: *const GrugValue) -> GrugValue;
+		safe fn game_fn_fmod        <'a>(state: &'a GrugState, arguments: *const GrugValue) -> GrugValue;
 	}
 
 	pub fn register_game_functions(state: &mut GrugState) { unsafe {
@@ -131,6 +132,7 @@ mod game_functions {
 		state.register_host_fn("y"           , game_fn_y           ).unwrap();
 		state.register_host_fn("sqrt"        , game_fn_sqrt        ).unwrap();
 		state.register_host_fn("set_acc"     , game_fn_set_acc     ).unwrap();
+		state.register_host_fn("fmod"        , game_fn_fmod        ).unwrap();
 	}}
 }
 

--- a/gruggers/tests/grug_tests/main.rs
+++ b/gruggers/tests/grug_tests/main.rs
@@ -36,7 +36,7 @@ mod test_bindings {
 				)};
 			})
 			.set_backend(BytecodeBackend::new())
-			.build_state().ok()?;
+			.build_state().map_err(|err| println!("{:?}", err)).ok()?;
 		super::game_fn_bindings::register_game_functions(&mut state).ok()?;
 		// let files = state.compile_all_files();
 		let files = Vec::new();
@@ -98,7 +98,7 @@ mod test_bindings {
 			.split_once("-").unwrap()
 			.1;
 
-		let fn_id = state.get_on_fn_id(entity_type, fn_name).unwrap();
+		let fn_id = state.get_export_fn_id(entity_type, fn_name).unwrap();
 		let entity = unsafe{(&*&raw const CURRENT_ENTITY).as_ref()}
 			.expect("called init_globals already");
 		let args = if args_count == 0 {&[]} else {unsafe{std::slice::from_raw_parts(args, args_count)}};
@@ -214,7 +214,9 @@ use test_bindings::*;
 
 mod game_fn_bindings {
 	use gruggers::types::GrugValue;
-	use gruggers::state::{GrugState, StateError};
+	use gruggers::state::GrugState;
+	use gruggers::error::GrugError;
+	use gruggers::arena::Arena;
 	#[link(name = "tests", kind="dylib")]
 	#[allow(improper_ctypes)]
 	unsafe extern "C" {
@@ -258,46 +260,46 @@ mod game_fn_bindings {
         safe fn game_fn_box_number           <'a>(state: &'a GrugState, values: *const GrugValue) -> GrugValue;
         safe fn game_fn_print_csv            <'a>(state: &'a GrugState, values: *const GrugValue) -> GrugValue;
 	}
-	pub fn register_game_functions(state: &mut GrugState) -> Result<(), StateError> { unsafe {
-		state.register_game_fn("nothing",              game_fn_nothing             )?; 
-		state.register_game_fn("magic",                game_fn_magic               )?; 
-		state.register_game_fn("initialize",           game_fn_initialize          )?; 
-		state.register_game_fn("initialize_bool",      game_fn_initialize_bool     )?; 
-		state.register_game_fn("identity",             game_fn_identity            )?; 
-		state.register_game_fn("max",                  game_fn_max                 )?; 
-		state.register_game_fn("say",                  game_fn_say                 )?; 
-		state.register_game_fn("sin",                  game_fn_sin                 )?; 
-		state.register_game_fn("cos",                  game_fn_cos                 )?; 
-		state.register_game_fn("mega",                 game_fn_mega                )?; 
-		state.register_game_fn("get_false",            game_fn_get_false           )?; 
-		state.register_game_fn("set_is_happy",         game_fn_set_is_happy        )?; 
-		state.register_game_fn("mega_f32",             game_fn_mega_f32            )?; 
-		state.register_game_fn("mega_i32",             game_fn_mega_i32            )?; 
-		state.register_game_fn("draw",                 game_fn_draw                )?; 
-		state.register_game_fn("blocked_alrm",         game_fn_blocked_alrm        )?; 
-		state.register_game_fn("spawn",                game_fn_spawn               )?; 
-		state.register_game_fn("spawn_d",              game_fn_spawn_d             )?; 
-		state.register_game_fn("has_resource",         game_fn_has_resource        )?; 
-		state.register_game_fn("has_entity",           game_fn_has_entity          )?; 
-		state.register_game_fn("has_string",           game_fn_has_string          )?; 
-		state.register_game_fn("get_opponent",         game_fn_get_opponent        )?; 
-		state.register_game_fn("set_d",                game_fn_set_d               )?; 
-		state.register_game_fn("get_os",               game_fn_get_os              )?; 
-		state.register_game_fn("set_opponent",         game_fn_set_opponent        )?; 
-		state.register_game_fn("motherload",           game_fn_motherload          )?; 
-		state.register_game_fn("motherload_subless",   game_fn_motherload_subless  )?; 
-		state.register_game_fn("offset_32_bit_f32",    game_fn_offset_32_bit_f32   )?; 
-		state.register_game_fn("offset_32_bit_i32",    game_fn_offset_32_bit_i32   )?; 
-		state.register_game_fn("offset_32_bit_string", game_fn_offset_32_bit_string)?; 
-		state.register_game_fn("talk",                 game_fn_talk                )?; 
-		state.register_game_fn("get_position",         game_fn_get_position        )?; 
-		state.register_game_fn("set_position",         game_fn_set_position        )?; 
-		state.register_game_fn("cause_game_fn_error",  game_fn_cause_game_fn_error )?; 
-		state.register_game_fn("call_on_b_fn",         game_fn_call_on_b_fn        )?; 
-		state.register_game_fn("store",                game_fn_store               )?; 
-		state.register_game_fn("retrieve",             game_fn_retrieve            )?; 
-		state.register_game_fn("box_number",           game_fn_box_number          )?; 
-		state.register_game_fn("print_csv",            game_fn_print_csv           )?; 
+	pub fn register_game_functions(state: &mut GrugState) -> Result<(), GrugError<Arena>> { unsafe {
+		state.register_host_fn("nothing",              game_fn_nothing             )?; 
+		state.register_host_fn("magic",                game_fn_magic               )?; 
+		state.register_host_fn("initialize",           game_fn_initialize          )?; 
+		state.register_host_fn("initialize_bool",      game_fn_initialize_bool     )?; 
+		state.register_host_fn("identity",             game_fn_identity            )?; 
+		state.register_host_fn("max",                  game_fn_max                 )?; 
+		state.register_host_fn("say",                  game_fn_say                 )?; 
+		state.register_host_fn("sin",                  game_fn_sin                 )?; 
+		state.register_host_fn("cos",                  game_fn_cos                 )?; 
+		state.register_host_fn("mega",                 game_fn_mega                )?; 
+		state.register_host_fn("get_false",            game_fn_get_false           )?; 
+		state.register_host_fn("set_is_happy",         game_fn_set_is_happy        )?; 
+		state.register_host_fn("mega_f32",             game_fn_mega_f32            )?; 
+		state.register_host_fn("mega_i32",             game_fn_mega_i32            )?; 
+		state.register_host_fn("draw",                 game_fn_draw                )?; 
+		state.register_host_fn("blocked_alrm",         game_fn_blocked_alrm        )?; 
+		state.register_host_fn("spawn",                game_fn_spawn               )?; 
+		state.register_host_fn("spawn_d",              game_fn_spawn_d             )?; 
+		state.register_host_fn("has_resource",         game_fn_has_resource        )?; 
+		state.register_host_fn("has_entity",           game_fn_has_entity          )?; 
+		state.register_host_fn("has_string",           game_fn_has_string          )?; 
+		state.register_host_fn("get_opponent",         game_fn_get_opponent        )?; 
+		state.register_host_fn("set_d",                game_fn_set_d               )?; 
+		state.register_host_fn("get_os",               game_fn_get_os              )?; 
+		state.register_host_fn("set_opponent",         game_fn_set_opponent        )?; 
+		state.register_host_fn("motherload",           game_fn_motherload          )?; 
+		state.register_host_fn("motherload_subless",   game_fn_motherload_subless  )?; 
+		state.register_host_fn("offset_32_bit_f32",    game_fn_offset_32_bit_f32   )?; 
+		state.register_host_fn("offset_32_bit_i32",    game_fn_offset_32_bit_i32   )?; 
+		state.register_host_fn("offset_32_bit_string", game_fn_offset_32_bit_string)?; 
+		state.register_host_fn("talk",                 game_fn_talk                )?; 
+		state.register_host_fn("get_position",         game_fn_get_position        )?; 
+		state.register_host_fn("set_position",         game_fn_set_position        )?; 
+		state.register_host_fn("cause_game_fn_error",  game_fn_cause_game_fn_error )?; 
+		state.register_host_fn("call_on_b_fn",         game_fn_call_on_b_fn        )?; 
+		state.register_host_fn("store",                game_fn_store               )?; 
+		state.register_host_fn("retrieve",             game_fn_retrieve            )?; 
+		state.register_host_fn("box_number",           game_fn_box_number          )?; 
+		state.register_host_fn("print_csv",            game_fn_print_csv           )?; 
 		Ok(())
 	}}
 }


### PR DESCRIPTION
Added new token types
updated parser.
renamed on_ to export and helper_ to local in docs and code
